### PR TITLE
feat: add pagination and search functionality to BlogsPage (#18)

### DIFF
--- a/app/(root)/(resources)/blogs/page.tsx
+++ b/app/(root)/(resources)/blogs/page.tsx
@@ -31,6 +31,7 @@ type BlogsPageProps = {
 			url: string;
 		};
 	};
+	searchParams: { [key: string]: string | string[] | undefined };
 };
 
 import { BlogsContentWidget, BlogsHeroWidget } from "@/components/index";
@@ -69,7 +70,11 @@ const BlogsPage = async () => {
 			</section>
 
 			<section id="content">
-				<BlogsContentWidget pasBlock={pasBlock} callToAction={callToAction} />
+				<BlogsContentWidget
+					pasBlock={pasBlock}
+					callToAction={callToAction}
+					searchParams={{}}
+				/>
 			</section>
 		</article>
 	);

--- a/components/blocks/hero-display-block.tsx
+++ b/components/blocks/hero-display-block.tsx
@@ -17,7 +17,7 @@ export const HeroDisplayBlock = ({
 				<ImageDisplayBlock imageSrc={image} imageAlt="Hero Image" />
 			</div>
 
-			<div className="absolute left-0 top-0 h-full w-full rounded-lg bg-black/20"></div>
+			<div className="absolute left-0 top-0 h-full w-full rounded-lg bg-black/10"></div>
 
 			{title && (
 				<div className="absolute left-1/2 top-1/2 w-72 -translate-x-1/2 -translate-y-1/2 rounded-lg bg-black/70 px-5 py-3 text-center lg:w-auto">

--- a/components/blocks/pagination-buttons-block.tsx
+++ b/components/blocks/pagination-buttons-block.tsx
@@ -1,0 +1,50 @@
+import Link from "next/link";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+import { Button } from "@/components/index";
+
+type PaginationButtonsBlockProps = {
+	page: number;
+	pathSegment: string;
+	search: string;
+	totalPages: number;
+};
+
+export const PaginationButtonsBlock = ({
+	page,
+	pathSegment,
+	search,
+	totalPages,
+}: PaginationButtonsBlockProps) => {
+	return (
+		<div className="flex items-center space-x-2">
+			<Button asChild size="icon" className="rounded-full">
+				<Link
+					href={{
+						pathname: `/${pathSegment}`,
+						query: {
+							...(search ? { search } : {}),
+							page: page > 1 ? page - 1 : 1,
+						},
+					}}
+				>
+					<ChevronLeft className="h-4 w-4 font-bold" />
+				</Link>
+			</Button>
+
+			<Button asChild size="icon" className="rounded-full">
+				<Link
+					href={{
+						pathname: `/${pathSegment}`,
+						query: {
+							...(search ? { search } : {}),
+							page: page < totalPages ? page + 1 : totalPages,
+						},
+					}}
+				>
+					<ChevronRight className="h-4 w-4 font-bold" />
+				</Link>
+			</Button>
+		</div>
+	);
+};

--- a/components/blocks/search-box-block.tsx
+++ b/components/blocks/search-box-block.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { SearchCheck } from "lucide-react";
+import { useDebounce } from "use-debounce";
+
+import { Input } from "@/components/index";
+
+type SearchBoxBlockProps = {
+	pathSegment: string;
+	search: string;
+};
+
+export const SearchBoxBlock = ({
+	pathSegment,
+	search,
+}: SearchBoxBlockProps) => {
+	const router = useRouter();
+
+	const initialRender = useRef(true);
+
+	const [text, setText] = useState(search);
+
+	const [query] = useDebounce(text, 500);
+
+	useEffect(() => {
+		if (initialRender.current) {
+			initialRender.current = false;
+			return;
+		}
+
+		if (!query) {
+			router.push(`/${pathSegment}`);
+		} else {
+			router.push(`/${pathSegment}?search=${query}`);
+		}
+	}, [pathSegment, query, router]);
+
+	return (
+		<div className="relative rounded-md">
+			<div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+				<SearchCheck className="h-5 w-5" />
+			</div>
+			<Input
+				value={text}
+				placeholder="Search..."
+				onChange={(e) => setText(e.target.value)}
+				className="block w-full rounded-md border-0 py-1.5 pl-10 text-foreground ring-1 ring-inset ring-muted-foreground placeholder:text-foreground focus:ring-2 focus:ring-inset focus:ring-primary sm:text-sm sm:leading-6"
+			/>
+		</div>
+	);
+};

--- a/components/index.ts
+++ b/components/index.ts
@@ -9,7 +9,9 @@ import { HeroDisplayBlock } from "@/components/blocks/hero-display-block";
 import { ImageDisplayBlock } from "@/components/blocks/image-display-block";
 import { NavigationFooterBlock } from "@/components/blocks/navigation-footer-block";
 import { NavigationHeaderBlock } from "@/components/blocks/navigation-header-block";
+import { PaginationButtonsBlock } from "@/components/blocks/pagination-buttons-block";
 import { RatingBlock } from "@/components/blocks/rating-block";
+import { SearchBoxBlock } from "@/components/blocks/search-box-block";
 import { SocialMediaSharingBlock } from "@/components/blocks/social-media-sharing-block";
 import { TestimonialCardBlock } from "@/components/blocks/testimonial-card-block";
 import { ThemeToggleBlock } from "@/components/blocks/theme-toggle-block";
@@ -25,6 +27,7 @@ import {
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 import {
 	Sheet,
@@ -75,8 +78,10 @@ export {
 	ImageDisplayBlock,
 	NavigationFooterBlock,
 	NavigationHeaderBlock,
-	SocialMediaSharingBlock,
+	PaginationButtonsBlock,
 	RatingBlock,
+	SearchBoxBlock,
+	SocialMediaSharingBlock,
 	TestimonialCardBlock,
 	ThemeToggleBlock,
 	Badge,
@@ -85,6 +90,7 @@ export {
 	DropdownMenuContent,
 	DropdownMenuItem,
 	DropdownMenuTrigger,
+	Input,
 	Separator,
 	Sheet,
 	SheetClose,

--- a/components/widgets/blogs-content-widget.tsx
+++ b/components/widgets/blogs-content-widget.tsx
@@ -3,8 +3,14 @@ import {
 	BlogSummaryCardBlock,
 	CallToActionBlock,
 	HeaderDisplayBlock,
+	PaginationButtonsBlock,
+	SearchBoxBlock,
+	Separator,
 } from "@/components/index";
-import { getAllBlogSummary } from "@/lib/data/read/index";
+import {
+	getAllBlogSummaryCount,
+	getAllBlogSummary,
+} from "@/lib/data/read/index";
 
 type BlogsContentWidgetProps = {
 	pasBlock: {
@@ -26,9 +32,10 @@ type BlogsContentWidgetProps = {
 			url: string;
 		};
 	};
+	searchParams: { [key: string]: string | string[] | undefined };
 };
 
-type blog = {
+type BlogProps = {
 	image: { public_id: string };
 	title: string;
 	slug: string;
@@ -39,8 +46,24 @@ type blog = {
 export const BlogsContentWidget = async ({
 	pasBlock,
 	callToAction,
+	searchParams,
 }: BlogsContentWidgetProps) => {
-	const blogs: blog = await getAllBlogSummary();
+	const page =
+		typeof searchParams.page === "string" ? Number(searchParams.page) : 1;
+
+	const limit =
+		typeof searchParams.limit === "string" ? Number(searchParams.limit) : 4;
+
+	const search =
+		typeof searchParams.search === "string" ? searchParams.search : "";
+
+	const summary: BlogProps = await getAllBlogSummary(page, limit, search);
+
+	const total = await getAllBlogSummaryCount();
+
+	const totalPages = summary ? Math.ceil(total.length / limit) : 0;
+
+	const pathSegment = "blogs";
 
 	return (
 		<Container>
@@ -52,25 +75,40 @@ export const BlogsContentWidget = async ({
 					/>
 
 					<div>
-						{blogs.length === 0 ? (
-							<p className="my-8 text-center leading-loose text-muted-foreground">
-								There are currently no blogs...
-							</p>
-						) : (
-							<div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
-								{blogs.map((blog, index) => (
-									<BlogSummaryCardBlock
-										key={index}
-										image={blog.image.public_id}
-										title={blog.title}
-										slug={blog.slug}
-										excerpt={blog.excerpt}
-										date={blog.date}
-									/>
-								))}
-							</div>
-						)}
+						<div className="mb-8 flex items-center space-x-3 lg:justify-end">
+							<SearchBoxBlock pathSegment={pathSegment} search={search} />
+
+							<PaginationButtonsBlock
+								page={page}
+								pathSegment={pathSegment}
+								search={search}
+								totalPages={totalPages}
+							/>
+						</div>
+
+						<div>
+							{summary.length === 0 ? (
+								<p className="my-8 text-center leading-loose text-muted-foreground">
+									There are currently no blogs...
+								</p>
+							) : (
+								<div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
+									{summary.map((blog, index) => (
+										<BlogSummaryCardBlock
+											key={index}
+											image={blog.image.public_id}
+											title={blog.title}
+											slug={blog.slug}
+											excerpt={blog.excerpt}
+											date={blog.date}
+										/>
+									))}
+								</div>
+							)}
+						</div>
 					</div>
+
+					<Separator className="my-8" />
 
 					<CallToActionBlock
 						image={callToAction.image.public_id}

--- a/components/widgets/home-content-widget.tsx
+++ b/components/widgets/home-content-widget.tsx
@@ -1,5 +1,5 @@
 import { Container } from "@/components/container";
-import { CallToActionBlock } from "@/components/index";
+import { CallToActionBlock, Separator } from "@/components/index";
 
 type HomeContentWidgetProps = {
 	callToAction: {
@@ -21,6 +21,8 @@ export const HomeContentWidget = ({ callToAction }: HomeContentWidgetProps) => {
 			<div className="py-8">
 				<div className="space-y-8">
 					<div>Home Content Widget</div>
+
+					<Separator className="my-8" />
 
 					<CallToActionBlock
 						image={callToAction.image.public_id}

--- a/components/widgets/testimonials-content-widget.tsx
+++ b/components/widgets/testimonials-content-widget.tsx
@@ -4,6 +4,7 @@ import { Container } from "@/components/container";
 import {
 	CallToActionBlock,
 	HeaderDisplayBlock,
+	Separator,
 	TestimonialCardBlock,
 } from "@/components/index";
 
@@ -72,6 +73,8 @@ export const TestimonialsContentWidget = async ({
 							</div>
 						)}
 					</div>
+
+					<Separator className="my-8" />
 
 					<CallToActionBlock
 						image={callToAction.image.public_id}

--- a/lib/data/operations/queries/index.ts
+++ b/lib/data/operations/queries/index.ts
@@ -232,8 +232,13 @@ export const qryBlogsPage = gql`
 
 /* query to retrieve all blogs in summary */
 export const qryAllBlogSummary = gql`
-	query qryAllBlogSummary {
-		blogs(first: 89) {
+	query qryAllBlogSummary($first: Int!, $skip: Int!, $query: String) {
+		blogs(
+			first: $first
+			skip: $skip
+			where: { title_contains: $query }
+			orderBy: createdAt_DESC
+		) {
 			title
 			slug
 			date

--- a/lib/data/read/index.ts
+++ b/lib/data/read/index.ts
@@ -116,11 +116,16 @@ export const getBlogsPage = async () => {
 };
 
 /* get all blogs in summary */
-export const getAllBlogSummary = async () => {
+export const getAllBlogSummary = async (page = 1, limit = 4, query: any) => {
+	const skip = (page - 1) * limit;
+
 	try {
 		const result = await fetch(endpoint, {
 			method: "POST",
-			body: JSON.stringify({ query: qryAllBlogSummary }),
+			body: JSON.stringify({
+				query: qryAllBlogSummary,
+				variables: { first: limit, skip: skip, query: query },
+			}),
 			headers: { "Content-Type": "application/json" },
 		});
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
 		"sonner": "^1.4.0",
 		"tailwind-merge": "^2.2.1",
 		"tailwindcss-animate": "^1.0.7",
+		"use-debounce": "^10.0.0",
 		"zod": "^3.22.4"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ dependencies:
   tailwindcss-animate:
     specifier: ^1.0.7
     version: 1.0.7(tailwindcss@3.4.1)
+  use-debounce:
+    specifier: ^10.0.0
+    version: 10.0.0(react@18.2.0)
   zod:
     specifier: ^3.22.4
     version: 3.22.4
@@ -3973,6 +3976,15 @@ packages:
       '@types/react': 18.2.55
       react: 18.2.0
       tslib: 2.6.2
+    dev: false
+
+  /use-debounce@10.0.0(react@18.2.0):
+    resolution: {integrity: sha512-XRjvlvCB46bah9IBXVnq/ACP2lxqXyZj0D9hj4K5OzNroMDpTEBg8Anuh1/UfRTRs7pLhQ+RiNxxwZu9+MVl1A==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      react: '>=16.8.0'
+    dependencies:
+      react: 18.2.0
     dev: false
 
   /use-sidecar@1.1.2(@types/react@18.2.55)(react@18.2.0):


### PR DESCRIPTION
* feat: Add Separator component to blogs and home content widgets

This commit adds the Separator component to both the BlogsContentWidget and HomeContentWidget components. The Separator is used to visually separate sections within the widgets.

* feat: Update hero display block background opacity and add separator to testimonials content widget

The commit message follows the conventional commits specification with a description of less than 50 characters and in lowercase.

* feat: add pagination and search functionality to BlogsPage

- Added PaginationButtonsBlock component for navigating between pages.
- Added SearchBoxBlock component for searching blogs by title.
- Modified BlogsContentWidget to handle pagination and search parameters.
- Updated getAllBlogSummary function to accept page, limit, and query parameters.
- Updated gqlAllBlogSummary query to include variables for pagination and search.
- Updated package.json and pnpm-lock.yaml with new dependencies.