### PR TITLE
feat: update project page and widgets with solutions and excerpts (#28)

### DIFF
--- a/app/(root)/(business)/book-a-consult/page.tsx
+++ b/app/(root)/(business)/book-a-consult/page.tsx
@@ -16,7 +16,6 @@ type ConsultPageProps = {
 		header: {
 			content: {
 				header: { title: string; subtitle: string };
-				content: { html: string };
 			};
 		};
 	};
@@ -65,11 +64,14 @@ const ConsultPage = async () => {
 	return (
 		<article className="mt-24 space-y-8">
 			<section id="hero">
-				<ConsultHeroWidget heroActionBlock={heroActionBlock} />
+				<ConsultHeroWidget
+					heroActionBlock={heroActionBlock}
+					pasBlock={pasBlock}
+				/>
 			</section>
 
 			<section id="content">
-				<ConsultContentWidget pasBlock={pasBlock} callToAction={callToAction} />
+				<ConsultContentWidget callToAction={callToAction} />
 			</section>
 		</article>
 	);

--- a/app/(root)/(business)/privacy-policy/page.tsx
+++ b/app/(root)/(business)/privacy-policy/page.tsx
@@ -60,7 +60,10 @@ const PrivacyPolicyPage = async () => {
 	return (
 		<article className="mt-24 space-y-8">
 			<section id="hero">
-				<PrivacyPolicyHeroWidget heroActionBlock={heroActionBlock} />
+				<PrivacyPolicyHeroWidget
+					heroActionBlock={heroActionBlock}
+					pasBlock={pasBlock}
+				/>
 			</section>
 
 			<section id="content">

--- a/app/(root)/(resources)/blogs/[slug]/page.tsx
+++ b/app/(root)/(resources)/blogs/[slug]/page.tsx
@@ -95,7 +95,15 @@ const BlogPage = async ({ params }: ParamsProps) => {
 	return (
 		<article className="mt-24 space-y-8">
 			<section id="hero">
-				<BlogHeroWidget title={title} image={image.public_id} />
+				<BlogHeroWidget
+					authorName={author.name}
+					authorImage={author.image.public_id}
+					category={category.title}
+					date={date}
+					excerpt={excerpt}
+					image={image.public_id}
+					title={title}
+				/>
 			</section>
 
 			<section id="content">
@@ -103,9 +111,6 @@ const BlogPage = async ({ params }: ParamsProps) => {
 					authorName={author.name}
 					authorImage={author.image.public_id}
 					authorBio={author.bio.html}
-					date={date}
-					category={category.title}
-					excerpt={excerpt}
 					content={content.html}
 					shareSummary={excerpt}
 					shareTitle={title}

--- a/app/(root)/(resources)/blogs/page.tsx
+++ b/app/(root)/(resources)/blogs/page.tsx
@@ -16,7 +16,6 @@ type BlogsPageProps = {
 		header: {
 			content: {
 				header: { title: string; subtitle: string };
-				content: { html: string };
 			};
 		};
 	};
@@ -65,11 +64,14 @@ const BlogsPage = async () => {
 	return (
 		<article className="mt-24 space-y-8">
 			<section id="hero">
-				<BlogsHeroWidget heroActionBlock={heroActionBlock} />
+				<BlogsHeroWidget
+					heroActionBlock={heroActionBlock}
+					pasBlock={pasBlock}
+				/>
 			</section>
 
 			<section id="content">
-				<BlogsContentWidget pasBlock={pasBlock} callToAction={callToAction} />
+				<BlogsContentWidget callToAction={callToAction} />
 			</section>
 		</article>
 	);

--- a/app/(root)/(resources)/projects/[slug]/page.tsx
+++ b/app/(root)/(resources)/projects/[slug]/page.tsx
@@ -73,13 +73,16 @@ const ProjectPage = async ({ params }: ParamsProps) => {
 	return (
 		<article className="mt-24 space-y-8">
 			<section id="hero">
-				<ProjectHeroWidget title={title} image={image.public_id} />
+				<ProjectHeroWidget
+					title={title}
+					image={image.public_id}
+					solutions={solutions}
+					excerpt={excerpt}
+				/>
 			</section>
 
 			<section id="content">
 				<ProjectContentWidget
-					solutions={solutions}
-					excerpt={excerpt}
 					content={content.html}
 					shareSummary={excerpt}
 					shareTitle={title}

--- a/app/(root)/(resources)/projects/page.tsx
+++ b/app/(root)/(resources)/projects/page.tsx
@@ -16,7 +16,6 @@ type ProjectsPageProps = {
 		header: {
 			content: {
 				header: { title: string; subtitle: string };
-				content: { html: string };
 			};
 		};
 	};
@@ -65,14 +64,14 @@ const ProjectsPage = async () => {
 	return (
 		<article className="mt-24 space-y-8">
 			<section id="hero">
-				<ProjectsHeroWidget heroActionBlock={heroActionBlock} />
+				<ProjectsHeroWidget
+					heroActionBlock={heroActionBlock}
+					pasBlock={pasBlock}
+				/>
 			</section>
 
 			<section id="content">
-				<ProjectsContentWidget
-					pasBlock={pasBlock}
-					callToAction={callToAction}
-				/>
+				<ProjectsContentWidget callToAction={callToAction} />
 			</section>
 		</article>
 	);

--- a/app/(root)/(resources)/testimonials/page.tsx
+++ b/app/(root)/(resources)/testimonials/page.tsx
@@ -71,14 +71,14 @@ const TestimonialsPage = async () => {
 	return (
 		<article className="mt-24 space-y-8">
 			<section id="hero">
-				<TestimonialsHeroWidget heroActionBlock={heroActionBlock} />
+				<TestimonialsHeroWidget
+					heroActionBlock={heroActionBlock}
+					pasBlock={pasBlock}
+				/>
 			</section>
 
 			<section id="content">
-				<TestimonialsContentWidget
-					pasBlock={pasBlock}
-					callToAction={callToAction}
-				/>
+				<TestimonialsContentWidget callToAction={callToAction} />
 			</section>
 		</article>
 	);

--- a/app/(root)/(solutions)/support/page.tsx
+++ b/app/(root)/(solutions)/support/page.tsx
@@ -66,7 +66,10 @@ const SupportPage = async () => {
 	return (
 		<article className="mt-24 space-y-8">
 			<section id="hero">
-				<SupportHeroWidget heroActionBlock={heroActionBlock} />
+				<SupportHeroWidget
+					heroActionBlock={heroActionBlock}
+					pasBlock={pasBlock}
+				/>
 			</section>
 
 			<section id="content">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from "react";
+import { Inter } from "next/font/google";
 import type { Metadata } from "next";
 import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/next";
@@ -11,6 +12,12 @@ import "@smastrom/react-rating/style.css";
 import "@/app/styles/globals.css";
 
 export const revalidate = 60;
+
+const inter = Inter({
+	subsets: ["latin"],
+	display: "swap",
+	variable: "--font-inter",
+});
 
 /* get the url depending on the environment */
 const absoluteUrl =
@@ -34,7 +41,7 @@ type RootLayoutProps = {
 
 const RootLayout = ({ children }: RootLayoutProps) => {
 	return (
-		<html lang="en">
+		<html lang="en" className={`${inter.variable}`}>
 			<body className="scroll-smooth font-sans antialiased">
 				<ThemeProvider
 					attribute="class"

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -3,11 +3,7 @@ import {
 	getAllProjectSummaryCount,
 } from "@/lib/data/read/index";
 
-type BlogType = {
-	slug: string;
-};
-
-type ProjectType = {
+type SitemapType = {
 	slug: string;
 };
 
@@ -16,7 +12,7 @@ export default async function sitemap() {
 
 	const blogs = await getAllBlogSummaryCount();
 
-	const blogsUrl = blogs.map((blog: BlogType) => ({
+	const blogsUrl = blogs.map((blog: SitemapType) => ({
 		url: `${baseUrl}/blogs/${blog.slug}`,
 		lastModified: new Date(),
 		changeFrequency: "weekly",
@@ -25,7 +21,7 @@ export default async function sitemap() {
 
 	const projects = await getAllProjectSummaryCount();
 
-	const projectUrl = projects.map((project: ProjectType) => ({
+	const projectUrl = projects.map((project: SitemapType) => ({
 		url: `${baseUrl}/projects/${project.slug}`,
 		lastModified: new Date(),
 		changeFrequency: "weekly",

--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -1,5 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,500;0,600;0,800;1,300;1,400;1,500;1,600;1,700;1,800&family=Poppins:wght@100;200;300;400;500;600;700;800;900&display=swap");
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/components/blocks/hero-display-alternate-block.tsx
+++ b/components/blocks/hero-display-alternate-block.tsx
@@ -1,0 +1,114 @@
+import { Container } from "@/components/container";
+import {
+	Badge,
+	DateDisplayBlock,
+	HeaderDisplayBlock,
+	ImageDisplayBlock,
+	Separator,
+} from "@/components/index";
+
+type HeroDisplayAlternateBlockProps = {
+	image: string;
+	title?: string;
+	subtitleHT?: string;
+	subtitleHS?: string;
+	category?: string;
+	excerpt?: string;
+	authorImage?: string;
+	authorName?: string;
+	date?: string;
+	solutions?: { title: string }[];
+};
+
+export const HeroDisplayAlternateBlock = ({
+	image,
+	title,
+	subtitleHT,
+	subtitleHS,
+	category,
+	excerpt,
+	authorImage,
+	authorName,
+	date,
+	solutions,
+}: HeroDisplayAlternateBlockProps) => {
+	return (
+		<Container>
+			<div className="flex flex-col space-y-5 py-10 lg:h-[32rem] lg:flex-row lg:items-center lg:py-16">
+				<div className="w-full lg:w-1/2">
+					{category && (
+						<div className="mb-3">
+							<Badge className="m-[1px] text-sm">{category}</Badge>
+						</div>
+					)}
+
+					{solutions &&
+						solutions.map((service, index) =>
+							index === 0 ? (
+								<Badge key={index} className="m-[1px] mb-3 text-sm">
+									{service.title}
+								</Badge>
+							) : (
+								service.title && (
+									<Badge key={index} className="m-[1px] mb-3 text-sm">
+										{service.title}
+									</Badge>
+								)
+							),
+						)}
+
+					{title && (
+						<div className="lg:max-w-lg">
+							<h1 className="text-pretty text-3xl font-semibold tracking-wide lg:text-4xl">
+								{title}
+							</h1>
+
+							{subtitleHT && subtitleHS && (
+								<div className="mt-3 w-full">
+									<Separator className="my-3" />
+
+									<p className="text-pretty text-xl leading-loose text-muted-foreground">
+										<span>{subtitleHT}</span>: <span>{subtitleHS}</span>
+									</p>
+
+									<Separator className="my-3" />
+								</div>
+							)}
+
+							{excerpt && (
+								<div className="my-3 w-full">
+									<HeaderDisplayBlock subtitle={excerpt} />
+								</div>
+							)}
+						</div>
+					)}
+
+					{authorName && authorImage && date && (
+						<div className="flex items-center space-x-1">
+							<div className="relative mr-2 h-12 w-12 rounded-full">
+								<ImageDisplayBlock
+									imageSrc={authorImage}
+									imageAlt={authorName}
+								/>
+							</div>
+
+							<div className="flex flex-col text-muted-foreground">
+								<p className="text-sm">{authorName}</p>
+
+								<p className="text-xs">
+									<DateDisplayBlock date={date} />
+								</p>
+							</div>
+						</div>
+					)}
+				</div>
+
+				<div className="flex h-96 w-full items-center justify-center lg:w-1/2">
+					<div className="relative h-full w-full rounded-lg border">
+						<ImageDisplayBlock imageSrc={image} imageAlt="Hero Image" />
+					</div>
+				</div>
+			</div>
+		</Container>
+	);
+};

--- a/components/index.ts
+++ b/components/index.ts
@@ -5,6 +5,7 @@ import { CallToActionBlock } from "@/components/blocks/call-to-action-block";
 import { ConsultationFormBlock } from "@/components/blocks/consultation-form-block";
 import { ContentDisplayBlock } from "@/components/blocks/content-display-block";
 import { DateDisplayBlock } from "@/components/blocks/date-display-block";
+import { HeroDisplayAlternateBlock } from "@/components/blocks/hero-display-alternate-block";
 import { HeaderDisplayBlock } from "@/components/blocks/header-display-block";
 import { HeroDisplayBlock } from "@/components/blocks/hero-display-block";
 import { ImageDisplayBlock } from "@/components/blocks/image-display-block";
@@ -102,6 +103,7 @@ export {
 	ContentDisplayBlock,
 	DateDisplayBlock,
 	HeaderDisplayBlock,
+	HeroDisplayAlternateBlock,
 	HeroDisplayBlock,
 	ImageDisplayBlock,
 	ProjectSummaryCardBlock,

--- a/components/widgets/blog-content-widget.tsx
+++ b/components/widgets/blog-content-widget.tsx
@@ -1,12 +1,8 @@
 import { Container } from "@/components/container";
 import {
-	Badge,
 	BlogAuthorDetailsBlock,
 	CallToActionBlock,
 	ContentDisplayBlock,
-	DateDisplayBlock,
-	HeaderDisplayBlock,
-	ImageDisplayBlock,
 	Separator,
 	SocialMediaSharingBlock,
 } from "@/components/index";
@@ -15,9 +11,6 @@ type BlogContentWidgetProps = {
 	authorImage: string;
 	authorName: string;
 	authorBio: string;
-	date: string;
-	category: string;
-	excerpt: string;
 	content: string;
 	shareSummary: string;
 	shareTitle: string;
@@ -33,9 +26,6 @@ export const BlogContentWidget = ({
 	authorImage,
 	authorName,
 	authorBio,
-	date,
-	category,
-	excerpt,
 	content,
 	shareSummary,
 	shareTitle,
@@ -50,39 +40,6 @@ export const BlogContentWidget = ({
 		<Container>
 			<div className="py-8">
 				<div className="space-y-8">
-					<div>
-						<Separator className="mb-5" />
-
-						<div className="flex flex-col md:flex-row md:items-center md:justify-between">
-							<div className="flex items-center space-x-1">
-								<div className="relative mr-2 h-12 w-12 rounded-full">
-									<ImageDisplayBlock
-										imageSrc={authorImage}
-										imageAlt={authorName}
-									/>
-								</div>
-
-								<div className="flex flex-col text-muted-foreground">
-									<p className="text-sm">{authorName}</p>
-
-									<p className="text-xs">
-										<DateDisplayBlock date={date} />
-									</p>
-								</div>
-							</div>
-
-							<div className="my-3 md:my-0">
-								<Badge className="m-[1px] text-sm">{category}</Badge>
-							</div>
-						</div>
-
-						<Separator className="mt-5" />
-					</div>
-
-					<div>
-						<HeaderDisplayBlock subtitle={excerpt} />
-					</div>
-
 					<div>
 						<ContentDisplayBlock content={content} />
 					</div>

--- a/components/widgets/blog-hero-widget.tsx
+++ b/components/widgets/blog-hero-widget.tsx
@@ -1,11 +1,35 @@
-import { HeroDisplayBlock } from "@/components/index";
+import { HeroDisplayAlternateBlock } from "@/components/index";
 
-type BlogHeroWidgetProps = { title: string; image: string };
+type BlogHeroWidgetProps = {
+	authorImage: string;
+	authorName: string;
+	category: string;
+	date: string;
+	excerpt: string;
+	image: string;
+	title: string;
+};
 
-export const BlogHeroWidget = ({ title, image }: BlogHeroWidgetProps) => {
+export const BlogHeroWidget = ({
+	authorImage,
+	authorName,
+	category,
+	date,
+	excerpt,
+	image,
+	title,
+}: BlogHeroWidgetProps) => {
 	return (
 		<div className="mx-1">
-			<HeroDisplayBlock title={title} image={image} />
+			<HeroDisplayAlternateBlock
+				authorImage={authorImage}
+				authorName={authorName}
+				category={category}
+				date={date}
+				excerpt={excerpt}
+				image={image}
+				title={title}
+			/>
 		</div>
 	);
 };

--- a/components/widgets/blogs-content-widget.tsx
+++ b/components/widgets/blogs-content-widget.tsx
@@ -9,14 +9,6 @@ import {
 import { getAllBlogSummary } from "@/lib/data/read/index";
 
 type BlogsContentWidgetProps = {
-	pasBlock: {
-		header: {
-			content: {
-				header: { title: string; subtitle: string };
-				content: { html: string };
-			};
-		};
-	};
 	callToAction: {
 		image: { public_id: string };
 		title: string;
@@ -39,7 +31,6 @@ type BlogProps = {
 }[];
 
 export const BlogsContentWidget = async ({
-	pasBlock,
 	callToAction,
 }: BlogsContentWidgetProps) => {
 	const summary: BlogProps = await getAllBlogSummary();
@@ -49,19 +40,12 @@ export const BlogsContentWidget = async ({
 			<div className="py-8">
 				<div className="space-y-8">
 					<div>
-						<HeaderDisplayBlock
-							title={pasBlock.header.content.header.title}
-							subtitle={pasBlock.header.content.header.subtitle}
-						/>
-					</div>
-
-					<div>
 						{summary.length === 0 ? (
 							<p className="my-8 text-center leading-loose text-muted-foreground">
 								There are currently no blogs...
 							</p>
 						) : (
-							<div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
+							<div className="grid grid-cols-1 gap-5 lg:grid-cols-2">
 								{summary.map((blog, index) => (
 									<BlogSummaryCardBlock
 										key={index}

--- a/components/widgets/blogs-hero-widget.tsx
+++ b/components/widgets/blogs-hero-widget.tsx
@@ -1,4 +1,4 @@
-import { HeroDisplayBlock } from "@/components/index";
+import { HeroDisplayAlternateBlock } from "@/components/index";
 
 type BlogsHeroWidgetProps = {
 	heroActionBlock: {
@@ -7,14 +7,26 @@ type BlogsHeroWidgetProps = {
 			image: { public_id: string };
 		};
 	};
+	pasBlock: {
+		header: {
+			content: {
+				header: { title: string; subtitle: string };
+			};
+		};
+	};
 };
 
-export const BlogsHeroWidget = ({ heroActionBlock }: BlogsHeroWidgetProps) => {
+export const BlogsHeroWidget = ({
+	heroActionBlock,
+	pasBlock,
+}: BlogsHeroWidgetProps) => {
 	return (
 		<div className="mx-1">
-			<HeroDisplayBlock
-				title={heroActionBlock.content.content.header.title}
+			<HeroDisplayAlternateBlock
 				image={heroActionBlock.content.image.public_id}
+				title={heroActionBlock.content.content.header.title}
+				subtitleHT={pasBlock.header.content.header.title}
+				subtitleHS={pasBlock.header.content.header.subtitle}
 			/>
 		</div>
 	);

--- a/components/widgets/consult-content-widget.tsx
+++ b/components/widgets/consult-content-widget.tsx
@@ -12,14 +12,6 @@ import {
 } from "@/components/index";
 
 type ConsultContentWidgetProps = {
-	pasBlock: {
-		header: {
-			content: {
-				header: { title: string; subtitle: string };
-				content: { html: string };
-			};
-		};
-	};
 	callToAction: {
 		image: { public_id: string };
 		title: string;
@@ -45,7 +37,6 @@ type GlobalsProps = {
 };
 
 export const ConsultContentWidget = async ({
-	pasBlock,
 	callToAction,
 }: ConsultContentWidgetProps) => {
 	const { siteContactDetails }: GlobalsProps = await getGlobals();
@@ -54,13 +45,6 @@ export const ConsultContentWidget = async ({
 		<Container>
 			<div className="py-8">
 				<div className="space-y-8">
-					<div>
-						<HeaderDisplayBlock
-							title={pasBlock.header.content.header.title}
-							subtitle={pasBlock.header.content.header.subtitle}
-						/>
-					</div>
-
 					<div className="flex flex-col lg:flex-row">
 						<div className="lg:w-3/4">
 							<div className="mx-auto max-w-full rounded-lg border bg-secondary p-3">

--- a/components/widgets/consult-hero-widget.tsx
+++ b/components/widgets/consult-hero-widget.tsx
@@ -1,4 +1,4 @@
-import { HeroDisplayBlock } from "@/components/index";
+import { HeroDisplayAlternateBlock } from "@/components/index";
 
 type ConsultHeroWidgetProps = {
 	heroActionBlock: {
@@ -7,16 +7,26 @@ type ConsultHeroWidgetProps = {
 			image: { public_id: string };
 		};
 	};
+	pasBlock: {
+		header: {
+			content: {
+				header: { title: string; subtitle: string };
+			};
+		};
+	};
 };
 
 export const ConsultHeroWidget = ({
 	heroActionBlock,
+	pasBlock,
 }: ConsultHeroWidgetProps) => {
 	return (
 		<div className="mx-1">
-			<HeroDisplayBlock
-				title={heroActionBlock.content.content.header.title}
+			<HeroDisplayAlternateBlock
 				image={heroActionBlock.content.image.public_id}
+				title={heroActionBlock.content.content.header.title}
+				subtitleHT={pasBlock.header.content.header.title}
+				subtitleHS={pasBlock.header.content.header.subtitle}
 			/>
 		</div>
 	);

--- a/components/widgets/privacy-policy-content-widget.tsx
+++ b/components/widgets/privacy-policy-content-widget.tsx
@@ -1,11 +1,10 @@
 import { Container } from "@/components/container";
-import { ContentDisplayBlock, HeaderDisplayBlock } from "@/components/index";
+import { ContentDisplayBlock } from "@/components/index";
 
 type PrivacyPolicyContentWidgetProps = {
 	pasBlock: {
 		header: {
 			content: {
-				header: { title: string; subtitle: string };
 				content: { html: string };
 			};
 		};
@@ -19,13 +18,6 @@ export const PrivacyPolicyContentWidget = ({
 		<Container>
 			<div className="py-8">
 				<div className="space-y-8">
-					<div>
-						<HeaderDisplayBlock
-							title={pasBlock.header.content.header.title}
-							subtitle={pasBlock.header.content.header.subtitle}
-						/>
-					</div>
-
 					<div>
 						<ContentDisplayBlock
 							content={pasBlock.header.content.content.html}

--- a/components/widgets/privacy-policy-hero-widget.tsx
+++ b/components/widgets/privacy-policy-hero-widget.tsx
@@ -1,4 +1,4 @@
-import { HeroDisplayBlock } from "@/components/index";
+import { HeroDisplayAlternateBlock } from "@/components/index";
 
 type PrivacyPolicyHeroWidgetProps = {
 	heroActionBlock: {
@@ -7,16 +7,26 @@ type PrivacyPolicyHeroWidgetProps = {
 			image: { public_id: string };
 		};
 	};
+	pasBlock: {
+		header: {
+			content: {
+				header: { title: string; subtitle: string };
+			};
+		};
+	};
 };
 
 export const PrivacyPolicyHeroWidget = ({
 	heroActionBlock,
+	pasBlock,
 }: PrivacyPolicyHeroWidgetProps) => {
 	return (
 		<div className="mx-1">
-			<HeroDisplayBlock
-				title={heroActionBlock.content.content.header.title}
+			<HeroDisplayAlternateBlock
 				image={heroActionBlock.content.image.public_id}
+				title={heroActionBlock.content.content.header.title}
+				subtitleHT={pasBlock.header.content.header.title}
+				subtitleHS={pasBlock.header.content.header.subtitle}
 			/>
 		</div>
 	);

--- a/components/widgets/project-content-widget.tsx
+++ b/components/widgets/project-content-widget.tsx
@@ -1,16 +1,12 @@
 import { Container } from "@/components/container";
 import {
-	Badge,
 	CallToActionBlock,
 	ContentDisplayBlock,
-	HeaderDisplayBlock,
 	Separator,
 	SocialMediaSharingBlock,
 } from "@/components/index";
 
 type ProjectContentWidgetProps = {
-	excerpt: string;
-	solutions: { title: string }[];
 	content: string;
 	shareSummary: string;
 	shareTitle: string;
@@ -23,8 +19,6 @@ type ProjectContentWidgetProps = {
 };
 
 export const ProjectContentWidget = ({
-	excerpt,
-	solutions,
 	content,
 	shareSummary,
 	shareTitle,
@@ -39,32 +33,6 @@ export const ProjectContentWidget = ({
 		<Container>
 			<div className="py-8">
 				<div className="space-y-8">
-					<div>
-						<HeaderDisplayBlock subtitle={excerpt} />
-					</div>
-
-					<div>
-						<Separator className="mb-5" />
-
-						<div>
-							{solutions.map((service, index) =>
-								index === 0 ? (
-									<Badge key={index} className="m-[1px] text-sm">
-										{service.title}
-									</Badge>
-								) : (
-									service.title && (
-										<Badge key={index} className="m-[1px] text-sm">
-											{service.title}
-										</Badge>
-									)
-								),
-							)}
-						</div>
-
-						<Separator className="mt-5" />
-					</div>
-
 					<div>
 						<ContentDisplayBlock content={content} />
 					</div>

--- a/components/widgets/project-hero-widget.tsx
+++ b/components/widgets/project-hero-widget.tsx
@@ -1,11 +1,26 @@
-import { HeroDisplayBlock } from "@/components/index";
+import { HeroDisplayAlternateBlock } from "@/components/index";
 
-type ProjectHeroWidgetProps = { title: string; image: string };
+type ProjectHeroWidgetProps = {
+	excerpt: string;
+	solutions: { title: string }[];
+	title: string;
+	image: string;
+};
 
-export const ProjectHeroWidget = ({ title, image }: ProjectHeroWidgetProps) => {
+export const ProjectHeroWidget = ({
+	excerpt,
+	solutions,
+	title,
+	image,
+}: ProjectHeroWidgetProps) => {
 	return (
 		<div className="mx-1">
-			<HeroDisplayBlock title={title} image={image} />
+			<HeroDisplayAlternateBlock
+				excerpt={excerpt}
+				image={image}
+				solutions={solutions}
+				title={title}
+			/>
 		</div>
 	);
 };

--- a/components/widgets/projects-content-widget.tsx
+++ b/components/widgets/projects-content-widget.tsx
@@ -1,7 +1,6 @@
 import { Container } from "@/components/container";
 import {
 	CallToActionBlock,
-	HeaderDisplayBlock,
 	ProjectSummaryCardBlock,
 	Separator,
 } from "@/components/index";
@@ -9,14 +8,6 @@ import {
 import { getAllProjectSummary } from "@/lib/data/read/index";
 
 type ProjectsContentWidgetProps = {
-	pasBlock: {
-		header: {
-			content: {
-				header: { title: string; subtitle: string };
-				content: { html: string };
-			};
-		};
-	};
 	callToAction: {
 		image: { public_id: string };
 		title: string;
@@ -39,7 +30,6 @@ type ProjectProps = {
 }[];
 
 export const ProjectsContentWidget = async ({
-	pasBlock,
 	callToAction,
 }: ProjectsContentWidgetProps) => {
 	const summary: ProjectProps = await getAllProjectSummary();
@@ -49,19 +39,12 @@ export const ProjectsContentWidget = async ({
 			<div className="py-8">
 				<div className="space-y-8">
 					<div>
-						<HeaderDisplayBlock
-							title={pasBlock.header.content.header.title}
-							subtitle={pasBlock.header.content.header.subtitle}
-						/>
-					</div>
-
-					<div>
 						{summary.length === 0 ? (
 							<p className="my-8 text-center leading-loose text-muted-foreground">
 								There are currently no projects...
 							</p>
 						) : (
-							<div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
+							<div className="grid grid-cols-1 gap-5 lg:grid-cols-2">
 								{summary.map((project, index) => (
 									<ProjectSummaryCardBlock
 										key={index}

--- a/components/widgets/projects-hero-widget.tsx
+++ b/components/widgets/projects-hero-widget.tsx
@@ -1,4 +1,4 @@
-import { HeroDisplayBlock } from "@/components/index";
+import { HeroDisplayAlternateBlock } from "@/components/index";
 
 type ProjectsHeroWidgetProps = {
 	heroActionBlock: {
@@ -7,16 +7,26 @@ type ProjectsHeroWidgetProps = {
 			image: { public_id: string };
 		};
 	};
+	pasBlock: {
+		header: {
+			content: {
+				header: { title: string; subtitle: string };
+			};
+		};
+	};
 };
 
 export const ProjectsHeroWidget = ({
 	heroActionBlock,
+	pasBlock,
 }: ProjectsHeroWidgetProps) => {
 	return (
 		<div className="mx-1">
-			<HeroDisplayBlock
-				title={heroActionBlock.content.content.header.title}
+			<HeroDisplayAlternateBlock
 				image={heroActionBlock.content.image.public_id}
+				title={heroActionBlock.content.content.header.title}
+				subtitleHT={pasBlock.header.content.header.title}
+				subtitleHS={pasBlock.header.content.header.subtitle}
 			/>
 		</div>
 	);

--- a/components/widgets/support-content-widget.tsx
+++ b/components/widgets/support-content-widget.tsx
@@ -15,7 +15,6 @@ type SupportContentWidgetProps = {
 	pasBlock: {
 		header: {
 			content: {
-				header: { title: string; subtitle: string };
 				content: { html: string };
 			};
 			image: { public_id: string };
@@ -42,13 +41,6 @@ export const SupportContentWidget = ({
 		<Container>
 			<div className="py-8">
 				<div className="space-y-8">
-					<div>
-						<HeaderDisplayBlock
-							title={pasBlock.header.content.header.title}
-							subtitle={pasBlock.header.content.header.subtitle}
-						/>
-					</div>
-
 					<div className="lg:flex lg:justify-center">
 						<div className="overflow-hidden border bg-secondary lg:mx-3 lg:flex lg:w-full lg:max-w-7xl lg:rounded-lg lg:shadow-md">
 							<div className="lg:w-1/2">

--- a/components/widgets/support-hero-widget.tsx
+++ b/components/widgets/support-hero-widget.tsx
@@ -1,4 +1,4 @@
-import { HeroDisplayBlock } from "@/components/index";
+import { HeroDisplayAlternateBlock } from "@/components/index";
 
 type SupportHeroWidgetProps = {
 	heroActionBlock: {
@@ -7,16 +7,26 @@ type SupportHeroWidgetProps = {
 			image: { public_id: string };
 		};
 	};
+	pasBlock: {
+		header: {
+			content: {
+				header: { title: string; subtitle: string };
+			};
+		};
+	};
 };
 
 export const SupportHeroWidget = ({
 	heroActionBlock,
+	pasBlock,
 }: SupportHeroWidgetProps) => {
 	return (
 		<div className="mx-1">
-			<HeroDisplayBlock
-				title={heroActionBlock.content.content.header.title}
+			<HeroDisplayAlternateBlock
 				image={heroActionBlock.content.image.public_id}
+				title={heroActionBlock.content.content.header.title}
+				subtitleHT={pasBlock.header.content.header.title}
+				subtitleHS={pasBlock.header.content.header.subtitle}
 			/>
 		</div>
 	);

--- a/components/widgets/testimonials-content-widget.tsx
+++ b/components/widgets/testimonials-content-widget.tsx
@@ -3,20 +3,11 @@ import { getAllTestimonials } from "@/lib/data/read/index";
 import { Container } from "@/components/container";
 import {
 	CallToActionBlock,
-	HeaderDisplayBlock,
 	Separator,
 	TestimonialCardBlock,
 } from "@/components/index";
 
 type TestimonialsContentWidgetProps = {
-	pasBlock: {
-		header: {
-			content: {
-				header: { title: string; subtitle: string };
-				content: { html: string };
-			};
-		};
-	};
 	callToAction: {
 		image: { public_id: string };
 		title: string;
@@ -39,7 +30,6 @@ type Testimonial = {
 }[];
 
 export const TestimonialsContentWidget = async ({
-	pasBlock,
 	callToAction,
 }: TestimonialsContentWidgetProps) => {
 	const testimonials: Testimonial = await getAllTestimonials();
@@ -49,19 +39,12 @@ export const TestimonialsContentWidget = async ({
 			<div className="py-8">
 				<div className="space-y-8">
 					<div>
-						<HeaderDisplayBlock
-							title={pasBlock.header.content.header.title}
-							subtitle={pasBlock.header.content.header.subtitle}
-						/>
-					</div>
-
-					<div>
 						{testimonials.length === 0 ? (
 							<p className="my-8 text-center leading-loose text-muted-foreground">
 								There are currently no client testimonials...
 							</p>
 						) : (
-							<div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
+							<div className="grid grid-cols-1 gap-5 lg:grid-cols-3">
 								{testimonials.map((testimonial, index) => (
 									<TestimonialCardBlock
 										key={index}

--- a/components/widgets/testimonials-hero-widget.tsx
+++ b/components/widgets/testimonials-hero-widget.tsx
@@ -1,4 +1,4 @@
-import { HeroDisplayBlock } from "@/components/index";
+import { HeroDisplayAlternateBlock } from "@/components/index";
 
 type TestimonialsHeroWidgetProps = {
 	heroActionBlock: {
@@ -7,16 +7,26 @@ type TestimonialsHeroWidgetProps = {
 			image: { public_id: string };
 		};
 	};
+	pasBlock: {
+		header: {
+			content: {
+				header: { title: string; subtitle: string };
+			};
+		};
+	};
 };
 
 export const TestimonialsHeroWidget = ({
 	heroActionBlock,
+	pasBlock,
 }: TestimonialsHeroWidgetProps) => {
 	return (
 		<div className="mx-1">
-			<HeroDisplayBlock
-				title={heroActionBlock.content.content.header.title}
+			<HeroDisplayAlternateBlock
 				image={heroActionBlock.content.image.public_id}
+				title={heroActionBlock.content.content.header.title}
+				subtitleHT={pasBlock.header.content.header.title}
+				subtitleHS={pasBlock.header.content.header.subtitle}
 			/>
 		</div>
 	);

--- a/next.config.js
+++ b/next.config.js
@@ -1,17 +1,22 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  images: {
-    remotePatterns: [
-      {
-        protocol: "https",
-        hostname: "res.cloudinary.com",
-      },
-      {
-        protocol: "https",
-        hostname: "media.graphassets.com",
-      },
-    ],
-  },
+	images: {
+		remotePatterns: [
+			{
+				protocol: "https",
+				hostname: "res.cloudinary.com",
+			},
+			{
+				protocol: "https",
+				hostname: "media.graphassets.com",
+			},
+		],
+	},
+	logging: {
+		fetches: {
+			fullUrl: true,
+		},
+	},
 };
 
 module.exports = nextConfig;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -20,6 +20,9 @@ module.exports = {
 			},
 		},
 		extend: {
+			fontFamily: {
+				sans: ["var(--font-inter)"],
+			},
 			colors: {
 				border: "hsl(var(--border))",
 				input: "hsl(var(--input))",
@@ -74,9 +77,6 @@ module.exports = {
 				"accordion-down": "accordion-down 0.2s ease-out",
 				"accordion-up": "accordion-up 0.2s ease-out",
 			},
-		},
-		fontFamily: {
-			sans: "Poppins, sans-serif",
 		},
 	},
 	plugins: [require("@tailwindcss/typography"), require("tailwindcss-animate")],


### PR DESCRIPTION
* chore: adjust grid gap in widgets components

* chore: adjust grid gap in testimonials widget

* fix: update header display in project content widget

* feat(sitemap): refactor sitemap code to use a common type

The commit message summarizes the code changes by indicating that the sitemap code has been refactored to use a common type. The message follows the conventional commits specification with a description of less than 50 characters and in lowercase.

* feat(config): update next.config.js

This commit updates the `next.config.js` file by adding a new logging configuration for fetches and updating the indentation of the existing images remote patterns.

* feat: update project content widget

This commit updates the ProjectContentWidget component by moving the HeaderDisplayBlock component to a different position and removing duplicate code.

* feat: Add Inter font and update font styles

The code changes add the Inter font from Google Fonts and update the font styles in the layout and Tailwind configuration files. The Inter font is now used as the default sans-serif font throughout the application.

* feat: add HeroDisplayAlternateBlock component

This commit adds the HeroDisplayAlternateBlock component, which displays a hero section with an alternate layout. It includes an image, title, and subtitle. The component is imported in the components/index.ts file for easy access.

* feat: update ConsultHeroWidget and ConsultContentWidget

The code changes in this commit update the ConsultHeroWidget and ConsultContentWidget components. The ConsultHeroWidget component now imports HeroDisplayAlternateBlock instead of HeroDisplayBlock, and it also receives a new prop pasBlock. The ConsultContentWidget component no longer uses the pasBlock prop to render a HeaderDisplayBlock.

* feat: update book-a-consult and testimonials pages

This commit updates the `book-a-consult` and `testimonials` pages. It removes the `pasBlock` prop from the `ConsultContentWidget` and `TestimonialsContentWidget`, and adds it to the `TestimonialsHeroWidget`. It also updates the import statement for the `HeroDisplayAlternateBlock`.

* feat(support): update SupportPage and SupportHeroWidget components

- Updated SupportPage component to include pasBlock prop in the SupportHeroWidget.
- Removed unnecessary code from the SupportContentWidget component.
- Updated import statement in the SupportHeroWidget component to use HeroDisplayAlternateBlock instead of HeroDisplayBlock.

* feat: update blog page and widgets

- Updated the `BlogPage` component to pass additional props to the `BlogHeroWidget`.
- Updated the `BlogsPage` component to remove unnecessary props from the `BlogsHeroWidget` and add a new prop.
- Updated the `HeroDisplayAlternateBlock` component to include new props for category, excerpt, author image, author name, and date.
- Updated the `BlogContentWidget` component to remove unnecessary props and rearrange content blocks.
- Updated the `BlogHeroWidget` component to include new props for category, excerpt, author image, author name, and date.
- Updated the `BlogsContentWidget` component to remove unnecessary prop.

* feat: update project page and widgets with solutions and excerpts