### PR TITLE
feat: refactor about-content-widget to use PASJumbotronBlock (#44)

### DIFF
--- a/app/(root)/(business)/about/page.tsx
+++ b/app/(root)/(business)/about/page.tsx
@@ -1,14 +1,94 @@
+import { Metadata } from "next";
+import { getCldOgImageUrl } from "next-cloudinary";
+
+import { getAboutPage } from "@/lib/data/read/index";
+
+type AboutPageProps = {
+	pageTitle: string;
+	pageMetaDescription: string;
+	heroActionBlock: {
+		content: {
+			content: { header: { title: string } };
+			image: { public_id: string; secure_url: string };
+		};
+	};
+	pasBlock: {
+		header: {
+			content: {
+				header: {
+					title: string;
+					subtitle: string;
+				};
+				content: {
+					html: string;
+				};
+			};
+			image: { public_id: string };
+		};
+		list: {
+			content: {
+				header: {
+					title: string;
+				};
+				content: {
+					html: string;
+				};
+			};
+		}[];
+	};
+	callToAction: {
+		image: { public_id: string };
+		title: string;
+		content: {
+			html: string;
+		};
+		link: {
+			label: string;
+			url: string;
+		};
+	};
+};
+
 import { AboutContentWidget, AboutHeroWidget } from "@/components/index";
 
-const AboutPage = () => {
+export async function generateMetadata(): Promise<Metadata> {
+	const { pageTitle, pageMetaDescription, heroActionBlock }: AboutPageProps =
+		await getAboutPage();
+
+	return {
+		title: pageTitle,
+		description: pageMetaDescription,
+		openGraph: {
+			type: "article",
+			images: [
+				{
+					width: 1200,
+					height: 630,
+					url: getCldOgImageUrl({
+						src: heroActionBlock.content.image.public_id,
+						format: "jpg",
+					}),
+				},
+			],
+		},
+	};
+}
+
+const AboutPage = async () => {
+	const { heroActionBlock, pasBlock, callToAction }: AboutPageProps =
+		await getAboutPage();
+
 	return (
 		<article className="mt-24 space-y-8">
 			<section id="hero">
-				<AboutHeroWidget />
+				<AboutHeroWidget
+					heroActionBlock={heroActionBlock}
+					pasBlock={pasBlock}
+				/>
 			</section>
 
 			<section id="content">
-				<AboutContentWidget />
+				<AboutContentWidget pasBlock={pasBlock} callToAction={callToAction} />
 			</section>
 		</article>
 	);

--- a/components/blocks/hero-display-block.tsx
+++ b/components/blocks/hero-display-block.tsx
@@ -38,8 +38,8 @@ export const HeroDisplayBlock = ({
 				className="left-0 top-0 flex h-[32rem] w-full items-center justify-center rounded-lg bg-cover bg-center"
 				style={{ backgroundImage: `url(${image})` }}
 			>
-				<div className="flex h-full w-full flex-col items-center justify-center rounded-lg bg-gray-900/40 md:flex-row">
-					<div className="px-3 md:w-1/2">
+				<div className="flex h-full w-full flex-col items-center justify-center rounded-lg bg-gray-900/40 lg:flex-row">
+					<div className="px-3 lg:w-1/2">
 						{category && (
 							<div className="mb-3">
 								<Badge className="m-[1px] text-sm text-white">{category}</Badge>
@@ -113,7 +113,7 @@ export const HeroDisplayBlock = ({
 						)}
 					</div>
 
-					<div className="px-3 text-white md:w-1/2"></div>
+					<div className="px-3 text-white lg:w-1/2"></div>
 				</div>
 			</div>
 		</Container>

--- a/components/blocks/pas-jumbotron-block.tsx
+++ b/components/blocks/pas-jumbotron-block.tsx
@@ -1,0 +1,80 @@
+import {
+	ContentDisplayBlock,
+	HeaderDisplayBlock,
+	ImageDisplayBlock,
+	Separator,
+} from "@/components/index";
+
+type PASJumbotronBlockProps = {
+	image: string;
+	content: string;
+	pasBlock: {
+		list: {
+			content: {
+				header: {
+					title: string;
+				};
+				content: {
+					html: string;
+				};
+			};
+		}[];
+	};
+};
+
+export const PASJumbotronBlock = ({
+	image,
+	content,
+	pasBlock,
+}: PASJumbotronBlockProps) => {
+	return (
+		<div className="w-full space-y-5 rounded-lg border bg-secondary p-4">
+			<div>
+				<HeaderDisplayBlock
+					title="Bridging Success"
+					subtitle="The Superior Software Solutions story"
+				/>
+			</div>
+
+			<div className="flex flex-col gap-5 rounded-lg lg:flex-row">
+				<div className="px-1 lg:w-1/2">
+					<div className="relative h-64 w-full lg:h-72">
+						<ImageDisplayBlock imageSrc={image} imageAlt="About Image" />
+					</div>
+				</div>
+
+				<div className="space-y-5 px-1 lg:w-1/2">
+					<div>
+						<HeaderDisplayBlock
+							title="Michael Caesar"
+							subtitle="Founder @Superior Software Solutions"
+						/>
+					</div>
+
+					<div>
+						<ContentDisplayBlock content={content} />
+					</div>
+				</div>
+			</div>
+
+			<div className="grid grid-cols-1 gap-5 lg:grid-cols-3">
+				{pasBlock.list.map((item, index) => (
+					<div
+						key={index}
+						className="overflow-hidden rounded-lg border bg-secondary"
+					>
+						<div className="p-5">
+							<h3 className="text-lg font-semibold tracking-wide">
+								{item.content.header.title}
+							</h3>
+
+							<Separator className="my-3" />
+
+							<ContentDisplayBlock content={item.content.content.html} />
+						</div>
+					</div>
+				))}
+			</div>
+		</div>
+	);
+};

--- a/components/index.ts
+++ b/components/index.ts
@@ -13,6 +13,7 @@ import { ImageDisplayBlock } from "@/components/blocks/image-display-block";
 import { NavigationFooterBlock } from "@/components/blocks/navigation-footer-block";
 import { NavigationHeaderBlock } from "@/components/blocks/navigation-header-block";
 import { PASHeaderBlock } from "@/components/blocks/pas-header-block";
+import { PASJumbotronBlock } from "@/components/blocks/pas-jumbotron-block";
 import { ProjectSummaryCardBlock } from "@/components/blocks/project-summary-card-block";
 import { ProjectsCarouselBlock } from "@/components/blocks/projects-carousel-block";
 import { RatingBlock } from "@/components/blocks/rating-block";
@@ -131,6 +132,7 @@ export {
 	NavigationFooterBlock,
 	NavigationHeaderBlock,
 	PASHeaderBlock,
+	PASJumbotronBlock,
 	RatingBlock,
 	SocialMediaSharingBlock,
 	SolutionsPriceListBlock,

--- a/components/widgets/about-content-widget.tsx
+++ b/components/widgets/about-content-widget.tsx
@@ -1,12 +1,76 @@
 import { Container } from "@/components/container";
+import {
+	CallToActionBlock,
+	PASJumbotronBlock,
+	Separator,
+} from "@/components/index";
 
-type AboutContentWidgetProps = {};
+type AboutContentWidgetProps = {
+	pasBlock: {
+		header: {
+			content: {
+				header: {
+					title: string;
+					subtitle: string;
+				};
+				content: {
+					html: string;
+				};
+			};
+			image: { public_id: string };
+		};
+		list: {
+			content: {
+				header: {
+					title: string;
+				};
+				content: {
+					html: string;
+				};
+			};
+		}[];
+	};
+	callToAction: {
+		image: { public_id: string };
+		title: string;
+		content: {
+			html: string;
+		};
+		link: {
+			label: string;
+			url: string;
+		};
+	};
+};
 
-export const AboutContentWidget = ({}: AboutContentWidgetProps) => {
+export const AboutContentWidget = ({
+	pasBlock,
+	callToAction,
+}: AboutContentWidgetProps) => {
 	return (
 		<Container>
 			<div className="py-8">
-				<div className="space-y-8">About Content Widget</div>
+				<div className="space-y-8">
+					<div>
+						<PASJumbotronBlock
+							image={pasBlock.header.image.public_id}
+							content={pasBlock.header.content.content.html}
+							pasBlock={pasBlock}
+						/>
+					</div>
+
+					<Separator className="my-8" />
+
+					<div>
+						<CallToActionBlock
+							image={callToAction.image.public_id}
+							title={callToAction.title}
+							content={callToAction.content.html}
+							label={callToAction.link.label}
+							url={callToAction.link.url}
+						/>
+					</div>
+				</div>
 			</div>
 		</Container>
 	);

--- a/components/widgets/about-hero-widget.tsx
+++ b/components/widgets/about-hero-widget.tsx
@@ -1,5 +1,33 @@
-type AboutHeroWidgetProps = {};
+import { HeroDisplayBlock } from "@/components/index";
 
-export const AboutHeroWidget = ({}: AboutHeroWidgetProps) => {
-	return <div className="mx-1">About Hero Widget</div>;
+type AboutHeroWidgetProps = {
+	heroActionBlock: {
+		content: {
+			content: { header: { title: string } };
+			image: { public_id: string; secure_url: string };
+		};
+	};
+	pasBlock: {
+		header: {
+			content: {
+				header: { title: string; subtitle: string };
+			};
+		};
+	};
+};
+
+export const AboutHeroWidget = ({
+	heroActionBlock,
+	pasBlock,
+}: AboutHeroWidgetProps) => {
+	return (
+		<div className="mx-1">
+			<HeroDisplayBlock
+				image={heroActionBlock.content.image.secure_url}
+				title={heroActionBlock.content.content.header.title}
+				subtitleHT={pasBlock.header.content.header.title}
+				subtitleHS={pasBlock.header.content.header.subtitle}
+			/>
+		</div>
+	);
 };

--- a/lib/data/operations/queries/index.ts
+++ b/lib/data/operations/queries/index.ts
@@ -679,3 +679,59 @@ export const qrySolutionBySlug = gql`
 		}
 	}
 `;
+
+/* query to retrieve about page */
+export const qryAboutPage = gql`
+	query qryAboutPage {
+		pages(where: { slug: "about" }) {
+			pageTitle
+			slug
+			pageMetaDescription
+			heroActionBlock {
+				content {
+					content {
+						header {
+							title
+						}
+					}
+					image
+				}
+			}
+			pasBlock {
+				header {
+					content {
+						header {
+							title
+							subtitle
+						}
+						content {
+							html
+						}
+					}
+					image
+				}
+				list {
+					content {
+						header {
+							title
+						}
+						content {
+							html
+						}
+					}
+				}
+			}
+			callToAction {
+				image
+				title
+				content {
+					html
+				}
+				link {
+					label
+					url
+				}
+			}
+		}
+	}
+`;

--- a/lib/data/read/index.ts
+++ b/lib/data/read/index.ts
@@ -1,4 +1,5 @@
 import {
+	qryAboutPage,
 	qryAllBlogSummary,
 	qryAllBlogSummaryCount,
 	qryAllProjectSummary,
@@ -358,5 +359,22 @@ export const getSolutionBySlug = async (slug: string) => {
 		return data.solutions[0];
 	} catch (error) {
 		console.log("GET_SOLUTION_BY_SLUG", error);
+	}
+};
+
+/* get about page */
+export const getAboutPage = async () => {
+	try {
+		const result = await fetch(endpoint, {
+			method: "POST",
+			body: JSON.stringify({ query: qryAboutPage }),
+			headers: { "Content-Type": "application/json" },
+		});
+
+		const { data } = await result.json();
+
+		return data.pages[0];
+	} catch (error) {
+		console.log("[GET_ABOUT_PAGE]", error);
 	}
 };


### PR DESCRIPTION
* feat(about): add about page components and data retrieval

This commit adds the necessary components and functions to display the about page. It includes the AboutHeroWidget, AboutContentWidget, and their respective props. The getAboutPage function is also added to retrieve the necessary data for the about page from the backend.



* feat(about-page): Update AboutPage component and AboutContentWidget

This commit updates the AboutPage component and the AboutContentWidget to include additional props for pasBlock. It also adds new components such as HeaderDisplayBlock, ImageDisplayBlock, and ContentDisplayBlock. The changes allow for displaying dynamic content in the AboutPage section.

The code changes include modifications to the page.tsx file in the (root)/(business)/about directory and the about-content-widget.tsx file in the components/widgets directory. Additionally, there are updates to the queries/index.ts file in the lib/data/operations/queries directory.

These changes enhance the functionality and appearance of the AboutPage component by incorporating new features and improving content display.

* feat: refactor about-content-widget to use PASJumbotronBlock

This commit refactors the AboutContentWidget component to use the newly created PASJumbotronBlock component. The code changes include removing unnecessary imports and replacing the previous header, image, and content display blocks with the new PASJumbotronBlock.

---------