### PR TITLE
feat: update HomePage component to include pasBlock (#48)

### DIFF
--- a/app/(root)/(home)/page.tsx
+++ b/app/(root)/(home)/page.tsx
@@ -10,12 +10,44 @@ type HomePageProps = {
 	pageMetaDescription: string;
 	heroActionBlock: {
 		content: {
-			content: { header: { title: string; subtitle: string } };
-			image: { public_id: string };
+			content: {
+				header: {
+					title: string;
+					subtitle: string;
+				};
+			};
+			image: {
+				public_id: string;
+				secure_url: string;
+			};
 		};
 		links: {
 			label: string;
 			url: string;
+		}[];
+	};
+	pasBlock: {
+		header: {
+			content: {
+				header: {
+					title: string;
+					subtitle: string;
+				};
+				content: {
+					html: string;
+				};
+			};
+			image: { public_id: string };
+		};
+		list: {
+			content: {
+				header: {
+					title: string;
+				};
+				content: {
+					html: string;
+				};
+			};
 		}[];
 	};
 	callToAction: {
@@ -55,16 +87,17 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 const HomePage = async () => {
-	const { heroActionBlock, callToAction }: HomePageProps = await getHomePage();
+	const { heroActionBlock, pasBlock, callToAction }: HomePageProps =
+		await getHomePage();
 
 	return (
-		<article className="mt-24 space-y-8">
+		<article className="mt-24 space-y-10">
 			<section id="hero">
 				<HomeHeroWidget heroActionBlock={heroActionBlock} />
 			</section>
 
 			<section id="content">
-				<HomeContentWidget callToAction={callToAction} />
+				<HomeContentWidget pasBlock={pasBlock} callToAction={callToAction} />
 			</section>
 		</article>
 	);

--- a/components/blocks/pas-jumbotron-block.tsx
+++ b/components/blocks/pas-jumbotron-block.tsx
@@ -6,6 +6,9 @@ import {
 } from "@/components/index";
 
 type PASJumbotronBlockProps = {
+	title?: string;
+	subtitle?: string;
+	displayTitle: boolean;
 	image: string;
 	content: string;
 	pasBlock: {
@@ -23,6 +26,9 @@ type PASJumbotronBlockProps = {
 };
 
 export const PASJumbotronBlock = ({
+	title,
+	subtitle,
+	displayTitle,
 	image,
 	content,
 	pasBlock,
@@ -30,10 +36,14 @@ export const PASJumbotronBlock = ({
 	return (
 		<div className="w-full space-y-5 rounded-lg border bg-secondary p-4">
 			<div>
-				<HeaderDisplayBlock
-					title="Bridging Success"
-					subtitle="The Superior Software Solutions story"
-				/>
+				{displayTitle ? (
+					<HeaderDisplayBlock
+						title="Bridging Success"
+						subtitle="The Superior Software Solutions story"
+					/>
+				) : (
+					<HeaderDisplayBlock title={title} subtitle={subtitle} />
+				)}
 			</div>
 
 			<div className="flex flex-col gap-5 rounded-lg lg:flex-row">
@@ -45,10 +55,17 @@ export const PASJumbotronBlock = ({
 
 				<div className="space-y-5 px-1 lg:w-1/2">
 					<div>
-						<HeaderDisplayBlock
-							title="Michael Caesar"
-							subtitle="Founder @Superior Software Solutions"
-						/>
+						{displayTitle ? (
+							<HeaderDisplayBlock
+								title="Michael Caesar"
+								subtitle="Founder @Superior Software Solutions."
+							/>
+						) : (
+							<HeaderDisplayBlock
+								title="Unmute Your Story"
+								subtitle="Crafting a digital experience that resonates."
+							/>
+						)}
 					</div>
 
 					<div>

--- a/components/widgets/about-content-widget.tsx
+++ b/components/widgets/about-content-widget.tsx
@@ -77,6 +77,7 @@ export const AboutContentWidget = ({
 							image={pasBlock.header.image.public_id}
 							content={pasBlock.header.content.content.html}
 							pasBlock={pasBlock}
+							displayTitle={true}
 						/>
 					</div>
 

--- a/components/widgets/home-content-widget.tsx
+++ b/components/widgets/home-content-widget.tsx
@@ -1,7 +1,35 @@
 import { Container } from "@/components/container";
-import { CallToActionBlock, Separator } from "@/components/index";
+import {
+	CallToActionBlock,
+	PASJumbotronBlock,
+	Separator,
+} from "@/components/index";
 
 type HomeContentWidgetProps = {
+	pasBlock: {
+		header: {
+			content: {
+				header: {
+					title: string;
+					subtitle: string;
+				};
+				content: {
+					html: string;
+				};
+			};
+			image: { public_id: string };
+		};
+		list: {
+			content: {
+				header: {
+					title: string;
+				};
+				content: {
+					html: string;
+				};
+			};
+		}[];
+	};
 	callToAction: {
 		image: { public_id: string };
 		title: string;
@@ -15,12 +43,24 @@ type HomeContentWidgetProps = {
 	};
 };
 
-export const HomeContentWidget = ({ callToAction }: HomeContentWidgetProps) => {
+export const HomeContentWidget = ({
+	pasBlock,
+	callToAction,
+}: HomeContentWidgetProps) => {
 	return (
 		<Container>
 			<div className="py-8">
-				<div className="space-y-8">
-					<div>Home Content Widget</div>
+				<div className="space-y-20">
+					<div>
+						<PASJumbotronBlock
+							image={pasBlock.header.image.public_id}
+							content={pasBlock.header.content.content.html}
+							pasBlock={pasBlock}
+							displayTitle={false}
+							title={pasBlock.header.content.header.title}
+							subtitle={pasBlock.header.content.header.subtitle}
+						/>
+					</div>
 
 					<Separator className="my-8" />
 

--- a/components/widgets/home-hero-widget.tsx
+++ b/components/widgets/home-hero-widget.tsx
@@ -1,11 +1,20 @@
-import { Button, ImageDisplayBlock } from "@/components/index";
 import Link from "next/link";
+
+import { Button } from "@/components/index";
 
 type HomeHeroWidgetProps = {
 	heroActionBlock: {
 		content: {
-			content: { header: { title: string; subtitle: string } };
-			image: { public_id: string };
+			content: {
+				header: {
+					title: string;
+					subtitle: string;
+				};
+			};
+			image: {
+				public_id: string;
+				secure_url: string;
+			};
 		};
 		links: {
 			label: string;
@@ -17,40 +26,38 @@ type HomeHeroWidgetProps = {
 export const HomeHeroWidget = ({ heroActionBlock }: HomeHeroWidgetProps) => {
 	return (
 		<div className="mx-1">
-			<div className="relative">
-				<div className="relative h-[75vh] w-full">
-					<ImageDisplayBlock
-						imageSrc={heroActionBlock.content.image.public_id}
-						imageAlt={heroActionBlock.content.content.header.title}
-					/>
+			<div
+				className="left-0 top-0 flex h-[75vh] w-full items-center justify-center rounded-lg bg-cover bg-center"
+				style={{
+					backgroundImage: `url(${heroActionBlock.content.image.secure_url})`,
+				}}
+			>
+				<div className="flex h-full w-full flex-col items-center justify-center rounded-lg bg-gray-900/40 lg:flex-row lg:gap-8">
+					<div className="container mx-auto flex max-w-6xl">
+						<div className="space-y-5 lg:w-1/2">
+							<h1 className="text-pretty text-3xl font-semibold tracking-wide text-white lg:text-5xl">
+								{heroActionBlock.content.content.header.title}
+							</h1>
 
-					<div className="absolute left-0 top-0 h-[75vh] w-full rounded-lg bg-black/50"></div>
+							<p className="text-pretty text-lg leading-loose text-white">
+								{heroActionBlock.content.content.header.subtitle}
+							</p>
 
-					<div className="absolute left-0 top-0 flex h-full w-full items-center justify-center">
-						<div className="max-w-6xl md:flex md:gap-8">
-							<div className="px-3 md:w-1/2">
-								<h1 className="text-pretty text-3xl font-bold tracking-tight text-white">
-									{heroActionBlock.content.content.header.title}
-								</h1>
-
-								<p className="mt-6 text-pretty text-lg leading-loose text-white">
-									{heroActionBlock.content.content.header.subtitle}
-								</p>
-
-								<div className="mt-8">
-									<Button asChild>
+							<div>
+								{heroActionBlock.links.map((link, index) => (
+									<Button asChild key={index}>
 										<Link
-											href={heroActionBlock.links[0].url}
+											href={link.url}
 											className="text-lg font-semibold uppercase"
 										>
-											{heroActionBlock.links[0].label}
+											{link.label}
 										</Link>
 									</Button>
-								</div>
+								))}
 							</div>
-
-							<div className="px-3 md:w-1/2"></div>
 						</div>
+
+						<div className="px-3 lg:w-1/2"></div>
 					</div>
 				</div>
 			</div>

--- a/lib/data/operations/queries/index.ts
+++ b/lib/data/operations/queries/index.ts
@@ -116,6 +116,30 @@ export const qryHomePage = gql`
 					url
 				}
 			}
+			pasBlock {
+				header {
+					content {
+						header {
+							title
+							subtitle
+						}
+						content {
+							html
+						}
+					}
+					image
+				}
+				list {
+					content {
+						header {
+							title
+						}
+						content {
+							html
+						}
+					}
+				}
+			}
 			callToAction {
 				image
 				title


### PR DESCRIPTION
* feat(homepage): update home page layout and hero widget

This commit updates the layout of the home page by adjusting the spacing between sections. It also modifies the hero widget component to display a background image and improve the alignment of text and buttons. Additionally, it adds support for rendering HTML content within the hero widget.

Conventional Commits Specification:
- Type: feat
- Scope: homepage
- Description: update home page layout and hero widget

* feat: Update home page content and hero widget styling

The code changes include removing the "content" property from the HomePageProps type in page.tsx, updating the text size and width of the title in home-hero-widget.tsx, and removing the "content" property from qryHomePage query in index.ts.

* feat: update HomePage component to include pasBlock

This commit updates the HomePage component to include the pasBlock prop. It also adds the pasBlock prop to the HomeContentWidget and AboutContentWidget components.